### PR TITLE
integrate FE and BE of dashboard activity and learned words

### DIFF
--- a/backend/activities/api/views.py
+++ b/backend/activities/api/views.py
@@ -13,12 +13,12 @@ class GetAllActivitiesAPI(APIView):
         response_load = {}
         count =0
 
-        activities = Activity.objects.all().order_by('activity_date')
+        activities = Activity.objects.all().order_by('-activity_date')
         for activity in activities:
             serialized = ActivitySerializer(activity)
             response_load[count] = serialized.data
             count +=1
-        return Response(response_load, status=status.HTTP_400_BAD_REQUEST)
+        return Response(response_load, status=status.HTTP_200_OK)
 
 class GetActivitiesAPI(APIView):
     def get(self, request, pk):

--- a/frontend/src/components/activitiesPanel.js
+++ b/frontend/src/components/activitiesPanel.js
@@ -13,12 +13,12 @@ const ActivitiesPanel = ({ otherUserID, all }) => {
   useEffect(() => {
     const fetchData = async () => {
       if (!all) {
-        const { data } = await activityService.getActivities(
+        const { data } = await activityService.getUser(
           otherUserID ? otherUserID : user.id
         );
         setActivities(data);
       } else {
-        const { data } = await activityService.getAllActivities();
+        const { data } = await activityService.getAllUsers();
         setActivities(data);
       }
     };

--- a/frontend/src/components/activitiesPanel.js
+++ b/frontend/src/components/activitiesPanel.js
@@ -6,16 +6,21 @@ import { UserContext } from "../utils/userContext";
 import Activity from "./activity";
 import * as activityService from "../services/activityService";
 
-const ActivitiesPanel = ({ otherUserID }) => {
+const ActivitiesPanel = ({ otherUserID, all }) => {
   const [activities, setActivities] = useState();
   const { user } = useContext(UserContext);
 
   useEffect(() => {
     const fetchData = async () => {
-      const { data } = await activityService.getActivities(
-        otherUserID ? otherUserID : user.id
-      );
-      setActivities(data);
+      if (!all) {
+        const { data } = await activityService.getActivities(
+          otherUserID ? otherUserID : user.id
+        );
+        setActivities(data);
+      } else {
+        const { data } = await activityService.getAllActivities();
+        setActivities(data);
+      }
     };
     fetchData();
   }, []);

--- a/frontend/src/components/learnedWordsPanel.js
+++ b/frontend/src/components/learnedWordsPanel.js
@@ -2,7 +2,7 @@ import React from "react";
 import Container from "react-bootstrap/Container";
 import WordEntry from "./word";
 
-const WordsPanel = () => {
+const WordsPanel = ({ data }) => {
   return (
     <Container className="pt-4 bg-light">
       <Container
@@ -24,16 +24,11 @@ const WordsPanel = () => {
         <hr />
       </Container>
       <Container style={{ columns: 2, columnRule: "4px outset gray" }}>
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
-        <WordEntry data={{ word: "word", answer: "answer" }} />
+        {Object.keys(data).map((key) => (
+          <React.Fragment key={key}>
+            <WordEntry data={data[key]} />
+          </React.Fragment>
+        ))}
       </Container>
     </Container>
   );

--- a/frontend/src/components/word.js
+++ b/frontend/src/components/word.js
@@ -1,16 +1,20 @@
 import React from "react";
 import Container from "react-bootstrap/Container";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
 import "../asset/style.css";
 
 const WordEntry = ({ data }) => {
+  console.log(data);
   return (
-    <Container
-      className="pt-2 bg-light rounded d-flex justify-content-around"
-      style={{ columns: 2 }}
-    >
-      <p>{data.word}</p>
-      <p>{data.answer}</p>
-    </Container>
+    <Row className="pt-2 bg-light rounded d-flex justify-content-around text-center">
+      <Col>
+        <p>{data.word}</p>
+      </Col>
+      <Col>
+        <p>{data.answer}</p>
+      </Col>
+    </Row>
   );
 };
 

--- a/frontend/src/pages/user/dashboard.js
+++ b/frontend/src/pages/user/dashboard.js
@@ -1,36 +1,92 @@
-import React from "react";
+import React, { useEffect, useState, useContext } from "react";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Image from "react-bootstrap/Image";
-import WordsPanel from "../../components/learnedWordsPanel";
-import avatarPlaceholder from "../../asset/avatar_placeholder.png";
+import { ArrowLeftCircle } from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
+import { domain } from "../../services/apis";
+
+import {
+  getCurrentProfile,
+  getLearnedWords,
+} from "../../services/profileService";
+import { UserContext } from "../../utils/userContext";
+import avatarPlaceholder from "../../asset/avatar_placeholder.png";
+import WordsPanel from "../../components/learnedWordsPanel";
+import ActivitiesPanel from "../../components/activitiesPanel";
 
 const Dashboard = () => {
-  return (
+  const { user } = useContext(UserContext);
+  const [showWords, setShowWords] = useState(false);
+  const [learnedWords, setLearnedWords] = useState();
+  const [profile, setProfile] = useState();
+  const [loading, setLoading] = useState(true);
+
+  const openWordsPanel = () => {
+    setShowWords(true);
+  };
+
+  useEffect(() => {
+    getCurrentProfile().then(({ data }) => {
+      setProfile(data);
+    });
+
+    getLearnedWords(user.id).then(({ data }) => {
+      setLearnedWords(data);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (profile && learnedWords) {
+      setLoading(false);
+    }
+  }, [profile, learnedWords]);
+
+  return !loading ? (
     <Container>
       <h1>Dashboard</h1>
       <Row>
         <Col md={3}>
           <Row>
             <Col md="auto">
-              <Image src={avatarPlaceholder} style={{ width: "6rem" }} />
+              <Image
+                src={domain + profile.profile.avatar || avatarPlaceholder}
+                style={{ width: "6rem" }}
+              />
             </Col>
             <Col md="auto">
-              <p>User Name</p>
-              <Link>Learned 0 words</Link>
+              <p className="text-capitalize fs-3">
+                {profile.user.first_name} {profile.user.last_name}
+              </p>
+              <Link onClick={openWordsPanel}>
+                Learned {profile.profile.total_words_learned} words
+              </Link>
               <br />
-              <Link>Learned 0 lessons</Link>
+              <p>Learned {profile.profile.total_lessons_learned} lessons</p>
             </Col>
           </Row>
         </Col>
         <Col>
-          <WordsPanel />
+          {showWords ? (
+            <React.Fragment>
+              <div
+                className="ms-4 mb-2 d-flex align-items-center"
+                style={{ cursor: "pointer" }}
+                onClick={() => setShowWords(false)}
+              >
+                <ArrowLeftCircle size={30} />
+                <h4 className="ms-2">Go Back</h4>
+              </div>
+              <WordsPanel data={learnedWords} />
+            </React.Fragment>
+          ) : (
+            <ActivitiesPanel all={true} />
+          )}
         </Col>
       </Row>
     </Container>
-  );
+  ) : null;
 };
 
 export default Dashboard;

--- a/frontend/src/services/activityService.js
+++ b/frontend/src/services/activityService.js
@@ -1,10 +1,10 @@
 import api from "./apis";
 import httpService from "./httpService";
 
-export function getActivities(id) {
+export function getUser(id) {
   return httpService.get(`${api}/activities/${id}`);
 }
 
-export function getAllActivities() {
+export function getAllUsers() {
   return httpService.get(`${api}/activities`);
 }

--- a/frontend/src/services/activityService.js
+++ b/frontend/src/services/activityService.js
@@ -4,3 +4,7 @@ import httpService from "./httpService";
 export function getActivities(id) {
   return httpService.get(`${api}/activities/${id}`);
 }
+
+export function getAllActivities() {
+  return httpService.get(`${api}/activities`);
+}

--- a/frontend/src/services/profileService.js
+++ b/frontend/src/services/profileService.js
@@ -48,3 +48,7 @@ export function getOtherProfile(id) {
 export function getProfilePageData(id) {
   return httpService.get(`${api}/profiles/data/${id}`);
 }
+
+export function getLearnedWords(id) {
+  return httpService.get(`${api}/profiles/${id}/words`);
+}


### PR DESCRIPTION
### **[Asana Link]**
https://app.asana.com/0/1202942780610695/1202942780610736/f
https://app.asana.com/0/1202942780610695/1202942780610776/f

### **[Commands]**
```
cd backend
python manage.py runserver
cd frontend
npm start
```

### **[Pre-conditions]**
go to `http://localhost:<YOUR_PORT>/home>` 




### **[Expected Output]**
dashboard will display all activities of all users
clicking the learned words button will toggle the display to list of learned words
user can go back to list of activities by clicking back button


### **[Notes]**


### **[Screenshots]**
![image](https://user-images.githubusercontent.com/111718037/194507929-d0a13119-1aea-41e8-be90-5acbab5a4542.png)
![image](https://user-images.githubusercontent.com/111718037/194513541-21215444-abd3-4f25-bd97-9b07b303c13d.png)
