### PR TITLE
fix text fields validation

### DIFF
--- a/backend/users/api/views.py
+++ b/backend/users/api/views.py
@@ -87,8 +87,8 @@ class UserAPI(APIView):
         user = User.objects.get(id=request.user.id)
         serializer = UserSerializer(user)
         response_load=serializer.data
-        profile = Profile.objects.get(user_id=request.user.id)
-        response_load['profile_id'] = Profile.objects.get(user_id=request.user.id).id
+        if (not user.is_staff):
+            response_load['profile_id'] = Profile.objects.get(user_id=request.user.id).id
 
         return Response(response_load)
 

--- a/frontend/src/components/categoryForm.js
+++ b/frontend/src/components/categoryForm.js
@@ -23,7 +23,7 @@ const CategoryForm = ({ state, handleChange, handleSave, error }) => {
           value={state?.description || ""}
         />
         {error && (
-          <Form.Text id={error.description} muted>
+          <Form.Text className="text-danger" id={error.description}>
             {error.description}
           </Form.Text>
         )}

--- a/frontend/src/components/input.js
+++ b/frontend/src/components/input.js
@@ -16,7 +16,7 @@ const InputField = forwardRef(
 
         {/* conditional rendering */}
         {error && (
-          <Form.Text id={name} muted>
+          <Form.Text className="text-danger" id={name}>
             {error}
           </Form.Text>
         )}

--- a/frontend/src/components/questionPanel.js
+++ b/frontend/src/components/questionPanel.js
@@ -19,7 +19,7 @@ const QuestionPanel = ({ question, handleChange, handleDelete, index }) => {
     choice_3: "",
   });
   const WORD = "word";
-  const CA = "correct_anwer";
+  const CA = "correct_answer";
   const C1 = "choice_1";
   const C2 = "choice_2";
   const C3 = "choice_3";

--- a/frontend/src/pages/admin/addWord.js
+++ b/frontend/src/pages/admin/addWord.js
@@ -19,7 +19,7 @@ const AdminAddWord = () => {
     choice_3: "",
   });
   const WORD = "word";
-  const CA = "correct_anwer";
+  const CA = "correct_answer";
   const C1 = "choice_1";
   const C2 = "choice_2";
   const C3 = "choice_3";


### PR DESCRIPTION
### **[Commands]**
```
cd backend
python manage.py runserver
cd frontend
npm start
```

### **[Pre-conditions]**
Input invalid values to text fields
Pages with text fields
- Login/ Register
- as admin: add/edit category, add/edit word
- as normal user: profile edit



### **[Expected Output]**
error messages are now in red
fixed the bug where correct answer field is not showing validation error


### **[Notes]**


### **[Screenshots]**
![image](https://user-images.githubusercontent.com/111718037/195233908-6cffedf3-a98e-496f-9056-541636f4eef0.png)

