### PR TITLE
fix profile edit page

### DIFF
--- a/backend/profiles/api/views.py
+++ b/backend/profiles/api/views.py
@@ -41,6 +41,7 @@ class updateProfileAPI(APIView):
             profileSerializer.save()
             return Response((profileSerializer.data, userProfileSerializer.data), status=status.HTTP_201_CREATED)
         elif (not userProfileSerializer.is_valid()):
+            print("debug")
             return Response(userProfileSerializer.errors, status=status.HTTP_400_BAD_REQUEST)
         elif (not profileSerializer.is_valid()):
             return Response(profileSerializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/users/api/serializers.py
+++ b/backend/users/api/serializers.py
@@ -26,7 +26,7 @@ class UserProfileUpdateSerializer(serializers.ModelSerializer):
     first_name = serializers.CharField(required=False)
     last_name = serializers.CharField(required=False)
     email = serializers.EmailField(required=False)
-    password = serializers.CharField(required=True, write_only=True)
+    password = serializers.CharField(required=False, write_only=True)
 
     class Meta:
         model = User

--- a/frontend/src/components/input.js
+++ b/frontend/src/components/input.js
@@ -2,7 +2,7 @@ import React, { forwardRef } from "react";
 import Form from "react-bootstrap/Form";
 
 const InputField = forwardRef(
-  ({ name, label, value, onChange, type, error }, ref) => {
+  ({ name, label, value, onChange, type, error, defaultValue }, ref) => {
     return (
       <Form.Group className="mb-3" controlId={name}>
         <Form.Label>{label}</Form.Label>
@@ -12,6 +12,7 @@ const InputField = forwardRef(
           placeholder={label}
           value={value}
           onChange={onChange}
+          defaultValue={defaultValue || null}
         />
 
         {/* conditional rendering */}

--- a/frontend/src/pages/user/editProfile.js
+++ b/frontend/src/pages/user/editProfile.js
@@ -14,6 +14,7 @@ import { getErrorMessage } from "../../utils/validation";
 const EditProfile = () => {
   const [state, setState] = useState();
   const [errors, setErrors] = useState({});
+  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
 
   let avatarFile = {};
@@ -29,6 +30,7 @@ const EditProfile = () => {
       };
 
       setState(payload);
+      setLoading(false);
     };
     fetchProfile();
   }, []);
@@ -39,7 +41,12 @@ const EditProfile = () => {
 
     if (Object.keys(errors).length === 0) {
       try {
-        const profileResponse = await profileService.update(state);
+        let load = state;
+        if (state.password === "" && state.password2 === "") {
+          const { password, password2, ...excluded } = state;
+          load = excluded;
+        }
+        const profileResponse = await profileService.update(load);
 
         const avatarResponse = await profileService.uploadAvatar(
           state,
@@ -87,7 +94,7 @@ const EditProfile = () => {
     avatarFile = formData;
   };
 
-  return (
+  return !loading ? (
     <Container>
       <Row>
         <Col md={{ span: 6, offset: 3 }}>
@@ -99,6 +106,7 @@ const EditProfile = () => {
                   name="first_name"
                   label="First Name"
                   type="text"
+                  defaultValue={state.first_name}
                   onChange={handleChange}
                   error={errors.first_name}
                 />
@@ -108,6 +116,7 @@ const EditProfile = () => {
                   name="last_name"
                   label="Last Name"
                   type="text"
+                  defaultValue={state.last_name}
                   onChange={handleChange}
                   error={errors.last_name}
                 />
@@ -118,6 +127,7 @@ const EditProfile = () => {
                 name="email"
                 label="Email"
                 type="text"
+                defaultValue={state.email}
                 onChange={handleChange}
                 error={errors.email}
               />
@@ -143,13 +153,13 @@ const EditProfile = () => {
               </Form.Group>
             </Row>
             <div className="d-grid gap-2">
-              <Button onClick={handleSubmit}>Save</Button>
+              <Button onClick={(e) => handleSubmit(e)}>Save</Button>
             </div>
           </Form>
         </Col>
       </Row>
     </Container>
-  );
+  ) : null;
 };
 
 export default EditProfile;


### PR DESCRIPTION
### **[Commands]**
```
cd backend
python manage.py runserver
cd frontend
npm start
```

### **[Pre-conditions]**
go to profile edit page



### **[Expected Output]**
`First Name` , `Last Name` and `Email` fields are pre-filled
`Password` is now optional

### **[Notes]**


### **[Screenshots]**
![image](https://user-images.githubusercontent.com/111718037/195258595-9349ceb0-495c-40bf-ba09-fa0d4ff00b7f.png)
